### PR TITLE
Allow blankposting

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -944,9 +944,6 @@ void Courtroom::on_character_ini_changed()
 
 void Courtroom::on_ic_message_return_pressed()
 {
-  if (ui_ic_chat_message_field->text() == "")
-    return;
-
   if ((anim_state < 3 || text_state < 2) && m_shout_state == 0)
     return;
 


### PR DESCRIPTION
Sending a completely blank message is no longer illegal on the clientside, mirroring behavior of AO which allows you to send emote-only messages.

Requires server-side changes as well for full function, for example https://github.com/Killing-Fever-Online/TsuserverDR-KFO/pull/1