### PR TITLE
Optional Chat ratelimit

### DIFF
--- a/res/ui/config_panel.ui
+++ b/res/ui/config_panel.ui
@@ -1019,17 +1019,37 @@
               </property>
              </widget>
             </item>
-            <item row="3" column="1">
+            <item row="4" column="1">
              <widget class="QSpinBox" name="FadeDurationBox">
               <property name="maximum">
                <number>600</number>
               </property>
              </widget>
             </item>
-            <item row="3" column="0">
+            <item row="4" column="0">
              <widget class="QLabel" name="CrossfadeLabel">
               <property name="text">
                <string>Crossfade:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="chat_ratelimit_label">
+              <property name="text">
+               <string>Enter Press Ratelimit:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="chat_ratelimit">
+              <property name="suffix">
+               <string> ms</string>
+              </property>
+              <property name="maximum">
+               <number>5000</number>
+              </property>
+              <property name="value">
+               <number>250</number>
               </property>
              </widget>
             </item>

--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -79,6 +79,7 @@ private:
   bool searchable_iniswap;
   bool always_pre;
   int chat_tick_interval;
+  int chat_ratelimit;
   bool emote_preview;
   bool sticky_sfx;
   int message_length_threshold;
@@ -193,6 +194,7 @@ void AOConfigPrivate::load_file()
   searchable_iniswap = cfg.value("searchable_iniswap", true).toBool();
   always_pre = cfg.value("always_pre", true).toBool();
   chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
+  chat_ratelimit = cfg.value("chat_ratelimit", 500).toInt();
   emote_preview = cfg.value("emote_preview", true).toBool();
   sticky_sfx = cfg.value("sticky_sfx", false).toBool();
   message_length_threshold = cfg.value("message_length_threshold", 70).toInt();
@@ -308,6 +310,7 @@ void AOConfigPrivate::save_file()
   cfg.setValue("searchable_iniswap", searchable_iniswap);
   cfg.setValue("always_pre", always_pre);
   cfg.setValue("chat_tick_interval", chat_tick_interval);
+  cfg.setValue("chat_ratelimit", chat_ratelimit);
   cfg.setValue("emote_preview", emote_preview);
   cfg.setValue("sticky_sfx", sticky_sfx);
   cfg.setValue("message_length_threshold", message_length_threshold);
@@ -604,6 +607,11 @@ bool AOConfig::always_pre_enabled() const
 int AOConfig::chat_tick_interval() const
 {
   return d->chat_tick_interval;
+}
+
+int AOConfig::chat_ratelimit() const
+{
+  return d->chat_ratelimit;
 }
 
 bool AOConfig::emote_preview_enabled() const
@@ -1017,6 +1025,14 @@ void AOConfig::set_chat_tick_interval(int p_number)
     return;
   d->chat_tick_interval = p_number;
   d->invoke_signal("chat_tick_interval_changed", Q_ARG(int, p_number));
+}
+
+void AOConfig::set_chat_ratelimit(int p_number)
+{
+  if (d->chat_ratelimit == p_number)
+    return;
+  d->chat_ratelimit = p_number;
+  d->invoke_signal("chat_ratelimit_changed", Q_ARG(int, p_number));
 }
 
 void AOConfig::set_emote_preview(bool p_enabled)

--- a/src/aoconfig.h
+++ b/src/aoconfig.h
@@ -48,6 +48,7 @@ public:
   bool searchable_iniswap_enabled() const;
   bool always_pre_enabled() const;
   int chat_tick_interval() const;
+  int chat_ratelimit() const;
   bool emote_preview_enabled() const;
   bool sticky_sfx_enabled() const;
   int message_length_threshold() const;
@@ -122,6 +123,7 @@ public slots:
   void set_searchable_iniswap(bool);
   void set_always_pre(bool p_enabled);
   void set_chat_tick_interval(int p_number);
+  void set_chat_ratelimit(int p_number);
   void set_emote_preview(bool p_enabled);
   void set_sticky_sfx(bool p_enabled);
   void set_message_length_threshold(int percent);
@@ -181,6 +183,7 @@ signals:
   void searchable_iniswap_changed(bool);
   void always_pre_changed(bool);
   void chat_tick_interval_changed(int);
+  void chat_ratelimit_changed(int);
   void emote_preview_changed(bool);
   void sticky_sfx_changed(bool);
 

--- a/src/aoconfigpanel.cpp
+++ b/src/aoconfigpanel.cpp
@@ -98,6 +98,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_searchable_iniswap = AO_GUI_WIDGET(QCheckBox, "searchable_iniswap");
   ui_always_pre = AO_GUI_WIDGET(QCheckBox, "always_pre");
   ui_chat_tick_interval = AO_GUI_WIDGET(QSpinBox, "chat_tick_interval");
+  ui_chat_ratelimit = AO_GUI_WIDGET(QSpinBox, "chat_ratelimit");
   ui_emote_preview = AO_GUI_WIDGET(QCheckBox, "emote_preview");
   ui_sticky_sfx = AO_GUI_WIDGET(QCheckBox, "sticky_sfx");
 
@@ -222,6 +223,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(m_config, SIGNAL(searchable_iniswap_changed(bool)), ui_searchable_iniswap, SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(always_pre_changed(bool)), ui_always_pre, SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(chat_tick_interval_changed(int)), ui_chat_tick_interval, SLOT(setValue(int)));
+  connect(m_config, SIGNAL(chat_ratelimit_changed(int)), ui_chat_ratelimit, SLOT(setValue(int)));
   connect(m_config, SIGNAL(emote_preview_changed(bool)), ui_emote_preview, SLOT(setChecked(bool)));
   connect(m_config, SIGNAL(sticky_sfx_changed(bool)), ui_sticky_sfx, SLOT(setChecked(bool)));
 
@@ -288,6 +290,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   connect(ui_searchable_iniswap, SIGNAL(toggled(bool)), m_config, SLOT(set_searchable_iniswap(bool)));
   connect(ui_always_pre, SIGNAL(toggled(bool)), m_config, SLOT(set_always_pre(bool)));
   connect(ui_chat_tick_interval, SIGNAL(valueChanged(int)), m_config, SLOT(set_chat_tick_interval(int)));
+  connect(ui_chat_ratelimit, SIGNAL(valueChanged(int)), m_config, SLOT(set_chat_ratelimit(int)));
   connect(ui_emote_preview, SIGNAL(toggled(bool)), m_config, SLOT(set_emote_preview(bool)));
   connect(ui_sticky_sfx, SIGNAL(toggled(bool)), m_config, SLOT(set_sticky_sfx(bool)));
 
@@ -359,6 +362,7 @@ AOConfigPanel::AOConfigPanel(AOApplication *p_ao_app, QWidget *p_parent)
   ui_searchable_iniswap->setChecked(m_config->searchable_iniswap_enabled());
   ui_always_pre->setChecked(m_config->always_pre_enabled());
   ui_chat_tick_interval->setValue(m_config->chat_tick_interval());
+  ui_chat_ratelimit->setValue(m_config->chat_ratelimit());
   ui_emote_preview->setChecked(m_config->emote_preview_enabled());
   ui_sticky_sfx->setChecked(m_config->sticky_sfx_enabled());
 

--- a/src/aoconfigpanel.h
+++ b/src/aoconfigpanel.h
@@ -126,6 +126,7 @@ private:
 
   // dialog
   QSpinBox *ui_chat_tick_interval = nullptr;
+  QSpinBox *ui_chat_ratelimit = nullptr;
   QSpinBox *ui_blip_rate = nullptr;
   QCheckBox *ui_blank_blips = nullptr;
   QSpinBox *ui_punctuation_delay = nullptr;

--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -1004,6 +1004,9 @@ void Courtroom::on_ic_message_return_pressed()
 {
   if ((anim_state < 3 || text_state < 2) && m_shout_state == 0)
     return;
+  ui_ic_chat_message_filter->blockSignals(true);
+  QTimer::singleShot(ao_config->chat_ratelimit(), this,
+                     [this] { ui_ic_chat_message_filter->blockSignals(false); });
 
   // MS
   // deskmod

--- a/src/courtroom_widgets.cpp
+++ b/src/courtroom_widgets.cpp
@@ -451,7 +451,11 @@ void Courtroom::connect_widgets()
   connect(ao_config, SIGNAL(showname_placeholder_changed(QString)), this, SLOT(on_showname_placeholder_changed(QString)));
   connect(ao_config, SIGNAL(character_ini_changed(QString)), this, SLOT(on_character_ini_changed()));
   connect(ui_ic_chat_showname, SIGNAL(editingFinished()), this, SLOT(on_ic_showname_editing_finished()));
-  connect(ui_ic_chat_message_field, SIGNAL(returnPressed()), this, SLOT(on_ic_message_return_pressed()));
+
+  // When the "emit" signal is sent in RPLineEditFilter, we call on_ic_message_return_pressed
+  connect(ui_ic_chat_message_filter, &RPLineEditFilter::chat_return_pressed, this,
+          &Courtroom::on_ic_message_return_pressed);
+
   connect(ao_config, SIGNAL(message_length_threshold_changed(int)), this, SLOT(handle_ic_message_length()));
   connect(ui_ic_chat_message_field, SIGNAL(textChanged(QString)), this, SLOT(handle_ic_message_length()));
   connect(ui_ic_chatlog->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(on_ic_chatlog_scroll_changed()));


### PR DESCRIPTION
Allows you to set your own chat Enter press ratelimit for IC chat, editable in the settings. It's 500ms by default, or half a second. This should prevent sending multiple messages in a quick succession even when you didn't intend to.