### PR TITLE
Fix upscaling being crunchy and low quality

### DIFF
--- a/src/aopixmap.cpp
+++ b/src/aopixmap.cpp
@@ -22,7 +22,8 @@ void AOPixmap::clear()
 QPixmap AOPixmap::scale(QSize p_size)
 {
   const bool l_pixmap_is_larger = m_pixmap.width() > p_size.width() || m_pixmap.height() > p_size.height();
-  const Qt::TransformationMode f_mode = l_pixmap_is_larger ? Qt::SmoothTransformation : Qt::FastTransformation;
+  // If we are downscaling, force smooth transformation as downscaling assets using fast algorithm looks like crap
+  const Qt::TransformationMode f_mode = l_pixmap_is_larger ? Qt::SmoothTransformation : m_mode;
   return m_pixmap.scaled(p_size, Qt::IgnoreAspectRatio, f_mode);
 }
 
@@ -30,5 +31,5 @@ QPixmap AOPixmap::scale_to_height(QSize p_size)
 {
   const bool l_pixmap_is_larger = m_pixmap.width() > p_size.width() || m_pixmap.height() > p_size.height();
   return m_pixmap.scaledToHeight(p_size.height(),
-                                 l_pixmap_is_larger ? Qt::SmoothTransformation : Qt::FastTransformation);
+                                 l_pixmap_is_larger ? Qt::SmoothTransformation : m_mode);
 }

--- a/src/aopixmap.h
+++ b/src/aopixmap.h
@@ -16,6 +16,8 @@ public:
 
 private:
   QPixmap m_pixmap;
+  // Default scaling mode for the pixmap
+  Qt::TransformationMode m_mode = Qt::SmoothTransformation;
 };
 
 #endif

--- a/src/mk2/spriteplayer.cpp
+++ b/src/mk2/spriteplayer.cpp
@@ -313,10 +313,6 @@ void SpritePlayer::resolve_scaling_mode(ScalingMode scalingMode, double scale)
   }
 
   m_transform = Qt::SmoothTransformation;
-  if (l_image_size.width() < m_size.width() || l_image_size.height() < m_size.height())
-  {
-    m_transform = Qt::FastTransformation;
-  }
 }
 
 void SpritePlayer::fetch_next_frame()


### PR DESCRIPTION
Fix scaling algorithm being "Fast" instead of "Smooth" while upscaling sprites
Set default scaling algorithm to Smooth for all AOPixMaps, which also results in cleaner themes