### PR TITLE
Reasonable defaults

### DIFF
--- a/src/aoconfig.cpp
+++ b/src/aoconfig.cpp
@@ -193,7 +193,7 @@ void AOConfigPrivate::load_file()
   manual_timeofday_selection = cfg.value("manual_timeofday", false).toBool();
   searchable_iniswap = cfg.value("searchable_iniswap", true).toBool();
   always_pre = cfg.value("always_pre", false).toBool();
-  chat_tick_interval = cfg.value("chat_tick_interval", 60).toInt();
+  chat_tick_interval = cfg.value("chat_tick_interval", 40).toInt();
   chat_ratelimit = cfg.value("chat_ratelimit", 500).toInt();
   emote_preview = cfg.value("emote_preview", true).toBool();
   sticky_sfx = cfg.value("sticky_sfx", false).toBool();


### PR DESCRIPTION
Change some default settings to be more reasonable and intuitive, namely:
* always_pre option should be OFF, so if you have a Preanimation on, sending a message will turn it off.
* chat_tick_interval will default to the faster 40 ms instead of slower 60 ms, matching the "normal" speed of ace attorney (though it could be argued it's still slow?)
more tbd