### PR TITLE
Add the ability to reformat a timer per server request

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -3945,6 +3945,14 @@ void Courtroom::set_timer_firing(int p_id, int firing_interval)
   l_timer->set_firing_interval(firing_interval);
 }
 
+void Courtroom::set_timer_format(int p_id, QString timer_format)
+{
+  if (p_id < 0 || p_id >= ui_timers.length())
+    return;
+  AOTimer *l_timer = ui_timers.at(p_id);
+  l_timer->set_timer_format(timer_format);
+}
+
 void Courtroom::pause_timer(int p_id)
 {
   if (p_id < 0 || p_id >= ui_timers.length())

--- a/src/courtroom.h
+++ b/src/courtroom.h
@@ -6,6 +6,7 @@
 #include "dro/interface/menus/area_menu.h"
 #include "dro/interface/menus/bgm_menu.h"
 #include "dro/interface/menus/char_menu.h"
+#include "dro/interface/widgets/aotimer.h"
 #include "dro/interface/widgets/bgm_filter.h"
 #include "dro/interface/widgets/evidencelist.h"
 #include "dro/interface/widgets/screenshot_button.h"
@@ -38,7 +39,6 @@ class AONotepad;
 class AOSfxPlayer;
 class AOShoutPlayer;
 class AOSystemPlayer;
-class AOTimer;
 class DRCharacterMovie;
 class DRChatLog;
 class DRMovie;
@@ -320,6 +320,7 @@ public:
   void set_timer_time(int timer_id, int new_time);
   void set_timer_timestep(int timer_id, int timestep_length);
   void set_timer_firing(int timer_id, int firing_interval);
+  void set_timer_format(int timer_id, QString timer_format = AOTimer::default_format);
   void pause_timer(int timer_id);
 
   template <typename T>

--- a/src/dro/interface/widgets/aotimer.cpp
+++ b/src/dro/interface/widgets/aotimer.cpp
@@ -12,6 +12,7 @@ AOTimer::AOTimer(QString name, QWidget *p_parent)
   setFrameStyle(QFrame::NoFrame);
   setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
   setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+  setWordWrapMode(QTextOption::NoWrap);
   setReadOnly(true);
 
   firing_timer = new QTimer(this);
@@ -97,13 +98,19 @@ void AOTimer::pause()
 
 void AOTimer::redraw()
 {
-  setText(manual_timer.get_time().toString("mm:ss.zzz"));
+  setText(manual_timer.get_time().toString(timer_format));
 }
 
 void AOTimer::set_time(QTime new_time)
 {
   manual_timer.set_time(new_time);
   old_manual_timer.set_time(new_time);
+  redraw();
+}
+
+void AOTimer::set_timer_format(QString new_timer_format)
+{
+  timer_format = new_timer_format;
   redraw();
 }
 

--- a/src/dro/interface/widgets/aotimer.h
+++ b/src/dro/interface/widgets/aotimer.h
@@ -31,7 +31,6 @@ public:
   {
     current_time = current_time.addMSecs(timestep_length);
   }
-
 private:
   QTime current_time;
   int timestep_length;
@@ -43,6 +42,7 @@ class AOTimer : public RPTextEdit
 
 public:
   AOTimer(QString name, QWidget *p_parent);
+  static const inline QString default_format = "mm:ss.zzz";
 
 public slots:
   void update_time();
@@ -51,6 +51,7 @@ public slots:
   void pause();
   void redraw();
   void set_time(QTime new_time);
+  void set_timer_format(QString new_timer_format = default_format);
   void set_timestep_length(int new_timestep_length);
   void set_firing_interval(int new_firing_interval);
   void set_concentrate_mode();
@@ -62,6 +63,8 @@ private:
   ManualTimer manual_timer;
   QTimer *firing_timer = nullptr;
   QTime start_time = QTime(0, 0);
+  // Formatted according to https://doc.qt.io/qt-6/qtime.html#toString
+  QString timer_format = default_format;
   // All of this is in miliseconds
   int manual_timer_timestep_length = -12;
   int firing_timer_length = 12;

--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -571,6 +571,17 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
     int firing_interval = l_content.at(1).toInt();
     m_courtroom->set_timer_firing(timer_id, firing_interval);
   }
+  else if (l_header == "TSR")
+  {
+    // Timer set Timer Format
+    if (l_content.size() != 2)
+      return;
+    if (!is_courtroom_constructed)
+      return;
+    int timer_id = l_content.at(0).toInt();
+    QString timer_format = l_content.at(1);
+    m_courtroom->set_timer_format(timer_id, timer_format);
+  }
   else if (l_header == "TP")
   {
     // Timer pause


### PR DESCRIPTION
Also disables word wrap for the timer

server side implementation is simple:
```py
self.send_command("TSR", timer_id, "hh:mm:ss.zzz")
```

timer is formatted according to https://doc.qt.io/qt-6/qtime.html#toString