### PR TITLE
Fix server names with an apostrophe breaking the log formatting

### DIFF
--- a/src/server_socket.cpp
+++ b/src/server_socket.cpp
@@ -203,7 +203,7 @@ void AOApplication::_p_handle_server_packet(DRPacket p_packet)
     static QRegularExpression validateFilename(R"([\\/:*?\"<>|\']")");
     QString log_folder = l_current_server.to_info().remove(validateFilename) + "/";
 
-    this->icchatlogsfilename = QDateTime::currentDateTimeUtc().toString("'" + log_folder + "'" + this->log_timestamp);
+    this->icchatlogsfilename = log_folder + QDateTime::currentDateTimeUtc().toString(this->log_timestamp);
     qInfo() << "setting log/replay name to " << this->icchatlogsfilename;
 
     construct_courtroom();


### PR DESCRIPTION
It caused a spam of folders to be created because the time formatting ended up spilling over into the folders rather than the filename as intended lol