### PR TITLE
Add Support for blips/ folder, fix blips being .wav only

### DIFF
--- a/src/aoapplication.cpp
+++ b/src/aoapplication.cpp
@@ -221,11 +221,16 @@ QString AOApplication::get_sfx_path(QString p_sfx)
 
 QString AOApplication::get_sfx_noext_path(QString p_file)
 {
+  return get_noext_path(p_file, get_sfx_dir_path());
+}
+
+QString AOApplication::get_noext_path(QString p_file, QString p_dir)
+{
   QString l_asset_path = nullptr;
-  QVector<QString> l_sfx_paths = get_all_package_and_base_paths(get_sfx_dir_path());
-  for(QString &l_sfx_path : l_sfx_paths)
+  QVector<QString> l_dir_paths = get_all_package_and_base_paths(p_dir);
+  for(QString &l_dir_path : l_dir_paths)
   {
-    l_asset_path = find_asset_path(l_sfx_path + "/" + p_file, FS::Formats::SupportedAudio());
+    l_asset_path = find_asset_path(l_dir_path + "/" + p_file, FS::Formats::SupportedAudio());
     if(l_asset_path != nullptr) break;
   }
 

--- a/src/aoapplication.h
+++ b/src/aoapplication.h
@@ -256,6 +256,7 @@ public:
   QString get_sfx_dir_path();
   QString get_sfx_path(QString sfx);
   QString get_sfx_noext_path(QString p_file);
+  QString get_noext_path(QString p_file, QString p_dir = "");
   QString get_ambient_sfx_path(QString p_file);
   QString get_character_sprite_path(QString character, QString emote, QString prefix, bool use_placeholder);
   QString get_character_sprite_pre_path(QString character, QString emote);

--- a/src/dro/system/audio.cpp
+++ b/src/dro/system/audio.cpp
@@ -140,12 +140,12 @@ namespace audio
 
     void SetGender(const char *gender)
     {
-      s_blipPlayer->set_blips("sfx-blip" + QString(gender) + ".wav");
+      s_blipPlayer->set_blips(gender);
     }
 
     void SetSound(const char *sound)
     {
-      s_blipPlayer->set_blips(sound);
+      s_blipPlayer->set_sound(sound);
     }
 
     int getBlipRate()

--- a/src/dro/system/audio/blip_player.cpp
+++ b/src/dro/system/audio/blip_player.cpp
@@ -1,6 +1,7 @@
 #include "blip_player.h"
 
 #include "aoapplication.h"
+#include "dro/fs/fs_reading.h"
 
 const int AOBlipPlayer::BLIP_COUNT = 5;
 
@@ -17,7 +18,23 @@ void AOBlipPlayer::set_blips(QString p_blip)
     return;
 
   m_name = p_blip;
-  m_file = ao_app->get_sfx_noext_path(m_name.value());
+  // First, test for raw asset in the sounds/blips/ folder
+  QString file = ao_app->find_asset_path({ao_app->get_noext_path(p_blip, "sounds/blips")}, FS::Formats::SupportedAudio());
+  if (!FS::Checks::FileExists(file))
+    // Next, check the DUMB WAY of sounds/general/sfx-blipmale.wav style. But also don't forget to allow non-wav blips.
+    file = ao_app->find_asset_path({ao_app->get_sfx_noext_path("sfx-blip" + p_blip)}, FS::Formats::SupportedAudio());
+  m_file = file;
+}
+
+void AOBlipPlayer::set_sound(QString p_blip)
+{
+  if (m_name.has_value() && m_name.value() == p_blip)
+    return;
+
+  m_name = p_blip;
+  // Search sound folder for the blip sfx
+  QString file = ao_app->find_asset_path({ao_app->get_sfx_noext_path(p_blip)}, FS::Formats::SupportedAudio());
+  m_file = file;
 }
 
 void AOBlipPlayer::blip_tick()

--- a/src/dro/system/audio/blip_player.h
+++ b/src/dro/system/audio/blip_player.h
@@ -20,6 +20,7 @@ public:
 
 public slots:
   void set_blips(QString p_sfx);
+  void set_sound(QString p_sfx);
   void blip_tick();
 
 private:


### PR DESCRIPTION
Add support for blips/ folder and fix only .wav blips being accepsted. Now all valid audio formats can be blipsounds
