### PR TITLE
Fix Evidence encoding breaking on & character

### DIFF
--- a/src/drpacket.cpp
+++ b/src/drpacket.cpp
@@ -39,3 +39,19 @@ QString DRPacket::to_string(const bool p_encode) const
     r_data += (p_encode ? encode(i_value) : i_value) + "#";
   return m_header + "#" + r_data + "%";
 }
+
+void DRPacket::escape(QStringList &contents)
+{
+  contents.replaceInStrings("#", "<num>")
+          .replaceInStrings("%", "<percent>")
+          .replaceInStrings("$", "<dollar>")
+          .replaceInStrings("&", "<and>");
+}
+
+void DRPacket::unescape(QStringList &contents)
+{
+  contents.replaceInStrings("<num>", "#")
+          .replaceInStrings("<percent>", "%")
+          .replaceInStrings("<dollar>", "$")
+          .replaceInStrings("<and>", "&");
+}

--- a/src/drpacket.h
+++ b/src/drpacket.h
@@ -16,6 +16,8 @@ public:
   const QStringList &get_content() const;
   QString to_string(const bool encode = false) const;
 
+  static void escape(QStringList &contents);
+  static void unescape(QStringList &contents);
 private:
   QString m_header;
   QStringList m_content;

--- a/src/drserversocket.cpp
+++ b/src/drserversocket.cpp
@@ -109,8 +109,6 @@ void DRServerSocket::_p_read_socket()
   {
     QStringList l_raw_data_list = i_raw_packet.split("#");
     const QString l_header = l_raw_data_list.takeFirst();
-    for (QString &i_raw_data : l_raw_data_list)
-      i_raw_data = DRPacket::decode(i_raw_data);
     Q_EMIT packet_received(DRPacket(l_header, l_raw_data_list));
   }
 }


### PR DESCRIPTION
Fix evidence packets not being able to have the & character without crashing out
