### PR TITLE
Fix Crash if App Path contains any non-English characters

### DIFF
--- a/src/dro/fs/fs_reading.cpp
+++ b/src/dro/fs/fs_reading.cpp
@@ -64,7 +64,7 @@ QString ApplicationPath()
     l_mac_path.cdUp();
   return l_mac_path.canonicalPath();
 #else
-  return QDir::currentPath();
+  return QDir::currentPath().toUtf8();
 #endif
 }
 


### PR DESCRIPTION
Fix crash on application startup if application path contains any non-English characters