### PR TITLE
Add "pixels" scaling support

### DIFF
--- a/src/courtroom.cpp
+++ b/src/courtroom.cpp
@@ -2454,7 +2454,7 @@ void Courtroom::setup_chat()
   m_chatbox_message_highlight_colors = ao_app->get_highlight_colors();
 
   QString f_gender = "male";
-  QString l_jsonPath = AOApplication::getInstance()->get_character_path(m_chatmessage[CMChrName], "char.json");
+  QString l_jsonPath = AOApplication::getInstance()->get_character_path(m_chatmessage[CMChrName], CHARACTER_CHAR_JSON);
   if(FS::Checks::FileExists(l_jsonPath))
   {
     ActorData *speakerActor = new ActorDataReader();

--- a/src/dro/param/actor/actor_loader.cpp
+++ b/src/dro/param/actor/actor_loader.cpp
@@ -15,7 +15,7 @@ ActorData *ActorLoader::GetCharacter(const QString& folder)
 {
   if(!s_CachedCharacters.contains(folder))
   {
-    QString charaConfigPath = AOApplication::getInstance()->get_character_path(folder, "char.json");
+    QString charaConfigPath = AOApplication::getInstance()->get_character_path(folder, CHARACTER_CHAR_JSON);
     ActorData *characterData;
     if(FS::Checks::FileExists(charaConfigPath))
     {
@@ -68,7 +68,7 @@ void ActorData::SwitchOutfit(const QString& t_outfit)
 void ActorDataReader::LoadActor(const QString& folder)
 {
   SetFolder(folder);
-  ReadFromFile(AOApplication::getInstance()->get_character_path(folder, "char.json"));
+  ReadFromFile(AOApplication::getInstance()->get_character_path(folder, CHARACTER_CHAR_JSON));
 
   SetShowname(getStringValue("showname"));
   SetGender(getStringValue("gender"));
@@ -249,6 +249,11 @@ void LegacyActorReader::LoadActor(const QString& folder)
   SetShowname(app->read_char_ini(folder, "options", "showname", folder).toString());
   SetSide(app->read_char_ini(folder, "options", "side", "wit").toString());
   SetGender("male");
+  QString scalingMode = app->read_char_ini(folder, "options", "scaling", "").toString();
+  if (scalingMode.startsWith("pixel"))
+  {
+    SetScalingMode("pixels");
+  }
 }
 
 QString LegacyActorReader::DRLookupKey(const QStringList &keys, const QString &target)

--- a/src/dro/param/actor/actor_loader.h
+++ b/src/dro/param/actor/actor_loader.h
@@ -64,6 +64,7 @@ public:
     {
       {"width_smooth", mk2::SpritePlayer::WidthSmoothScaling},
       {"width_pixels", mk2::SpritePlayer::WidthPixelScaling},
+      {"pixels", mk2::SpritePlayer::PixelScaling},
     };
 
     if(scalingModeMap.contains(m_ScalingMode.toLower())) return scalingModeMap[m_ScalingMode.toLower()];

--- a/src/dro/param/actor_repository.cpp
+++ b/src/dro/param/actor_repository.cpp
@@ -2,6 +2,7 @@
 #include <QMap>
 #include <QString>
 #include "aoapplication.h"
+#include "commondefs.h"
 #include "dro/fs/fs_reading.h"
 #include "dro/param/actor/actor_loader.h"
 
@@ -30,7 +31,7 @@ ActorData *dro::actor::user::load(QString folder)
   }
 
   s_currentFolder = folder;
-  QString l_jsonPath = AOApplication::getInstance()->get_character_path(folder, "char.json");
+  QString l_jsonPath = AOApplication::getInstance()->get_character_path(folder, CHARACTER_CHAR_JSON);
 
   if(FS::Checks::FileExists(l_jsonPath))
   {

--- a/src/dro/tools/button_maker.cpp
+++ b/src/dro/tools/button_maker.cpp
@@ -9,6 +9,7 @@
 #include <QMessageBox>
 #include <QFileDialog>
 #include "aoapplication.h"
+#include "commondefs.h"
 #include "dro/fs/fs_reading.h"
 #include "dro/interface/courtroom_layout.h"
 #include "dro/param/actor_repository.h"
@@ -150,7 +151,7 @@ void ButtonMaker::SetCharacter(QString character)
   m_EmoteIndex = 0;
   m_Emotes.clear();
 
-  m_Path = AOApplication::getInstance()->get_character_path(character, "char.json");
+  m_Path = AOApplication::getInstance()->get_character_path(character, CHARACTER_CHAR_JSON);
   if(FS::Checks::FileExists(m_Path))
   {
     m_IsJson = true;

--- a/src/mk2/spriteplayer.cpp
+++ b/src/mk2/spriteplayer.cpp
@@ -276,6 +276,13 @@ void SpritePlayer::resolve_scaling_mode(ScalingMode scalingMode, double scale)
       scale_current_frame();
       return;
     }
+    if(scalingMode == PixelScaling)
+    {
+      m_transform = Qt::FastTransformation;
+      m_resolved_scaling_mode = PixelScaling;
+      scale_current_frame();
+      return;
+    }
   }
   m_resolved_scaling_mode = m_scaling_mode;
 
@@ -438,7 +445,7 @@ void SpritePlayer::scale_current_frame()
     composed = composed.scaledToHeight(m_size.height() * m_scale, m_transform);
     break;
 
-    case WidthPixelScaling:
+  case WidthPixelScaling:
     {
       const int originalWidth = composed.width();
       if (originalWidth > 0)
@@ -452,6 +459,10 @@ void SpritePlayer::scale_current_frame()
         composed = composed.scaled(finalWidth, finalHeight, Qt::IgnoreAspectRatio, Qt::FastTransformation);
       }
     }
+
+  case PixelScaling:
+    composed = composed.scaledToHeight(m_size.height() * m_scale, Qt::FastTransformation);
+    break;
   }
 
   m_overallScale = static_cast<double>(composed.width()) / originalSize.width();

--- a/src/mk2/spriteplayer.h
+++ b/src/mk2/spriteplayer.h
@@ -45,6 +45,7 @@ public:
     DynamicScaling,
     WidthSmoothScaling,
     WidthPixelScaling,
+    PixelScaling,
     AutomaticScaling
   };
   Q_ENUM(ScalingMode)

--- a/src/modules/managers/character_manager.cpp
+++ b/src/modules/managers/character_manager.cpp
@@ -23,7 +23,7 @@ ActorData *CharacterManager::ReadCharacter(QString t_folder)
 {
   static QMap<QString, QPair<QDateTime, ActorData*>> s_cache;
 
-  QString l_jsonPath = AOApplication::getInstance()->get_character_path(t_folder, "char.json");
+  QString l_jsonPath = AOApplication::getInstance()->get_character_path(t_folder, CHARACTER_CHAR_JSON);
 
   if(FS::Checks::FileExists(l_jsonPath))
   {


### PR DESCRIPTION
Add support for char.ini scaling=pixel
Add a json option for "pixels" as well
This option will scale the sprite to height and use Fast transformation algorithm. It is NOT integer scaling as otherwise it would cut off the sprite and result in floating graphics at certain resolutions.